### PR TITLE
Add vocabulary training features

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -40,6 +40,13 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
         }}
       />
+      <Tabs.Screen
+        name="vocab/index"
+        options={{
+          title: 'Vocabulary',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="book.fill" color={color} />,
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/(tabs)/vocab/index.tsx
+++ b/app/(tabs)/vocab/index.tsx
@@ -1,0 +1,31 @@
+import { Link } from 'expo-router';
+import { View, FlatList, Button } from 'react-native';
+import { ThemedText } from '@/components/ThemedText';
+import { useVocabulary } from '@/contexts/VocabularyContext';
+
+export default function VocabularyScreen() {
+  const { words } = useVocabulary();
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <View style={{ flexDirection: 'row', gap: 12, marginBottom: 12 }}>
+        <Link href="/vocab/add" asChild>
+          <Button title="Add Word" />
+        </Link>
+        <Link href="/vocab/quiz" asChild>
+          <Button title="Quiz" />
+        </Link>
+      </View>
+      <FlatList
+        data={words}
+        keyExtractor={(_, idx) => String(idx)}
+        renderItem={({ item }) => (
+          <ThemedText>
+            {item.word} - {item.meaning}
+          </ThemedText>
+        )}
+        ListEmptyComponent={<ThemedText>No words yet.</ThemedText>}
+      />
+    </View>
+  );
+}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,6 +5,7 @@ import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { VocabularyProvider } from '@/contexts/VocabularyContext';
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
@@ -18,12 +19,14 @@ export default function RootLayout() {
   }
 
   return (
-    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen name="+not-found" />
-      </Stack>
-      <StatusBar style="auto" />
-    </ThemeProvider>
+    <VocabularyProvider>
+      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+        <Stack>
+          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+          <Stack.Screen name="+not-found" />
+        </Stack>
+        <StatusBar style="auto" />
+      </ThemeProvider>
+    </VocabularyProvider>
   );
 }

--- a/app/vocab/add.tsx
+++ b/app/vocab/add.tsx
@@ -1,0 +1,37 @@
+import { Stack, router } from 'expo-router';
+import { useState } from 'react';
+import { View, TextInput, Button } from 'react-native';
+
+import { useVocabulary } from '@/contexts/VocabularyContext';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function AddWordScreen() {
+  const { addWord } = useVocabulary();
+  const [word, setWord] = useState('');
+  const [meaning, setMeaning] = useState('');
+
+  const handleAdd = () => {
+    if (!word || !meaning) return;
+    addWord(word.trim(), meaning.trim());
+    router.back();
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 16, gap: 12 }}>
+      <Stack.Screen options={{ title: 'Add Word' }} />
+      <ThemedText>Word</ThemedText>
+      <TextInput
+        value={word}
+        onChangeText={setWord}
+        style={{ borderWidth: 1, padding: 8, borderRadius: 4 }}
+      />
+      <ThemedText>Meaning</ThemedText>
+      <TextInput
+        value={meaning}
+        onChangeText={setMeaning}
+        style={{ borderWidth: 1, padding: 8, borderRadius: 4 }}
+      />
+      <Button title="Save" onPress={handleAdd} />
+    </View>
+  );
+}

--- a/app/vocab/quiz/index.tsx
+++ b/app/vocab/quiz/index.tsx
@@ -1,0 +1,21 @@
+import { Stack } from 'expo-router';
+import { View } from 'react-native';
+import { Link } from 'expo-router';
+import { Button } from 'react-native';
+
+export default function QuizMenuScreen() {
+  return (
+    <View style={{ flex: 1, padding: 16, gap: 12 }}>
+      <Stack.Screen options={{ title: 'Quiz' }} />
+      <Link href="/vocab/quiz/meaning" asChild>
+        <Button title="Word -> Meaning" />
+      </Link>
+      <Link href="/vocab/quiz/word" asChild>
+        <Button title="Meaning -> Word" />
+      </Link>
+      <Link href="/vocab/quiz/scramble" asChild>
+        <Button title="Unscramble" />
+      </Link>
+    </View>
+  );
+}

--- a/app/vocab/quiz/meaning.tsx
+++ b/app/vocab/quiz/meaning.tsx
@@ -1,0 +1,55 @@
+import { Stack } from 'expo-router';
+import { useState } from 'react';
+import { View, Button } from 'react-native';
+import { ThemedText } from '@/components/ThemedText';
+import { useVocabulary } from '@/contexts/VocabularyContext';
+
+export default function QuizMeaningScreen() {
+  const { words } = useVocabulary();
+  const [current, setCurrent] = useState(0);
+  const [show, setShow] = useState(false);
+
+  if (words.length === 0) {
+    return (
+      <View style={{ flex: 1, padding: 16 }}>
+        <Stack.Screen options={{ title: 'Word -> Meaning' }} />
+        <ThemedText>No words to practice.</ThemedText>
+      </View>
+    );
+  }
+
+  const word = words[current];
+  const options = shuffle([word.meaning, ...randomMeanings(words, word.meaning)]);
+
+  const handleAnswer = (answer: string) => {
+    setShow(answer === word.meaning);
+  };
+
+  const next = () => {
+    setShow(false);
+    setCurrent((c) => (c + 1) % words.length);
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 16, gap: 12 }}>
+      <Stack.Screen options={{ title: 'Word -> Meaning' }} />
+      <ThemedText type="title">{word.word}</ThemedText>
+      {options.map((m) => (
+        <Button key={m} title={m} onPress={() => handleAnswer(m)} />
+      ))}
+      {show && <Button title="Next" onPress={next} />}
+    </View>
+  );
+}
+
+function randomMeanings(words: { meaning: string }[], exclude: string) {
+  const arr = words.map((w) => w.meaning).filter((m) => m !== exclude);
+  return shuffle(arr).slice(0, 3);
+}
+
+function shuffle<T>(array: T[]): T[] {
+  return array
+    .map((value) => ({ value, sort: Math.random() }))
+    .sort((a, b) => a.sort - b.sort)
+    .map(({ value }) => value);
+}

--- a/app/vocab/quiz/scramble.tsx
+++ b/app/vocab/quiz/scramble.tsx
@@ -1,0 +1,62 @@
+import { Stack } from 'expo-router';
+import { useState, useEffect } from 'react';
+import { View, Button } from 'react-native';
+import { ThemedText } from '@/components/ThemedText';
+import { useVocabulary } from '@/contexts/VocabularyContext';
+
+export default function QuizScrambleScreen() {
+  const { words } = useVocabulary();
+  const [current, setCurrent] = useState(0);
+  const [letters, setLetters] = useState<string[]>([]);
+  const [answer, setAnswer] = useState('');
+
+  if (words.length === 0) {
+    return (
+      <View style={{ flex: 1, padding: 16 }}>
+        <Stack.Screen options={{ title: 'Unscramble' }} />
+        <ThemedText>No words to practice.</ThemedText>
+      </View>
+    );
+  }
+
+  const word = words[current];
+
+  useEffect(() => {
+    setLetters(shuffle(word.word.split('')));
+    setAnswer('');
+  }, [current]);
+
+  const choose = (letter: string, idx: number) => {
+    setLetters((l) => l.filter((_, i) => i !== idx));
+    setAnswer((a) => a + letter);
+  };
+
+  const next = () => {
+    setLetters([]);
+    setAnswer('');
+    setCurrent((c) => (c + 1) % words.length);
+  };
+
+  const solved = letters.length === 0 && answer.toLowerCase() === word.word.toLowerCase();
+
+  return (
+    <View style={{ flex: 1, padding: 16, gap: 12 }}>
+      <Stack.Screen options={{ title: 'Unscramble' }} />
+      <ThemedText>{word.meaning}</ThemedText>
+      <ThemedText type="title">{answer}</ThemedText>
+      <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
+        {letters.map((l, idx) => (
+          <Button key={`${l}-${idx}`} title={l} onPress={() => choose(l, idx)} />
+        ))}
+      </View>
+      {solved && <Button title="Next" onPress={next} />}
+    </View>
+  );
+}
+
+function shuffle<T>(array: T[]): T[] {
+  return array
+    .map((value) => ({ value, sort: Math.random() }))
+    .sort((a, b) => a.sort - b.sort)
+    .map(({ value }) => value);
+}

--- a/app/vocab/quiz/word.tsx
+++ b/app/vocab/quiz/word.tsx
@@ -1,0 +1,55 @@
+import { Stack } from 'expo-router';
+import { useState } from 'react';
+import { View, Button } from 'react-native';
+import { ThemedText } from '@/components/ThemedText';
+import { useVocabulary } from '@/contexts/VocabularyContext';
+
+export default function QuizWordScreen() {
+  const { words } = useVocabulary();
+  const [current, setCurrent] = useState(0);
+  const [show, setShow] = useState(false);
+
+  if (words.length === 0) {
+    return (
+      <View style={{ flex: 1, padding: 16 }}>
+        <Stack.Screen options={{ title: 'Meaning -> Word' }} />
+        <ThemedText>No words to practice.</ThemedText>
+      </View>
+    );
+  }
+
+  const word = words[current];
+  const options = shuffle([word.word, ...randomWords(words, word.word)]);
+
+  const handleAnswer = (answer: string) => {
+    setShow(answer === word.word);
+  };
+
+  const next = () => {
+    setShow(false);
+    setCurrent((c) => (c + 1) % words.length);
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 16, gap: 12 }}>
+      <Stack.Screen options={{ title: 'Meaning -> Word' }} />
+      <ThemedText type="title">{word.meaning}</ThemedText>
+      {options.map((m) => (
+        <Button key={m} title={m} onPress={() => handleAnswer(m)} />
+      ))}
+      {show && <Button title="Next" onPress={next} />}
+    </View>
+  );
+}
+
+function randomWords(words: { word: string }[], exclude: string) {
+  const arr = words.map((w) => w.word).filter((m) => m !== exclude);
+  return shuffle(arr).slice(0, 3);
+}
+
+function shuffle<T>(array: T[]): T[] {
+  return array
+    .map((value) => ({ value, sort: Math.random() }))
+    .sort((a, b) => a.sort - b.sort)
+    .map(({ value }) => value);
+}

--- a/contexts/VocabularyContext.tsx
+++ b/contexts/VocabularyContext.tsx
@@ -1,0 +1,35 @@
+import React, { createContext, useContext, useState } from 'react';
+
+export type Word = {
+  word: string;
+  meaning: string;
+};
+
+interface VocabularyContextProps {
+  words: Word[];
+  addWord: (word: string, meaning: string) => void;
+}
+
+const VocabularyContext = createContext<VocabularyContextProps | undefined>(undefined);
+
+export function VocabularyProvider({ children }: { children: React.ReactNode }) {
+  const [words, setWords] = useState<Word[]>([]);
+
+  const addWord = (word: string, meaning: string) => {
+    setWords((prev) => [...prev, { word, meaning }]);
+  };
+
+  return (
+    <VocabularyContext.Provider value={{ words, addWord }}>
+      {children}
+    </VocabularyContext.Provider>
+  );
+}
+
+export function useVocabulary() {
+  const context = useContext(VocabularyContext);
+  if (!context) {
+    throw new Error('useVocabulary must be used within a VocabularyProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- create a `VocabularyContext` to hold words
- wrap the app with the provider
- add a new tab for vocabulary
- implement word list with add and quiz options
- implement quiz screens: word/meaning multiple choice and unscramble letters

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff638bf58832688d60ed7d1eccaa1