### PR TITLE
Enhance layout with SafeAreaView

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -13,6 +13,7 @@ export default function TabLayout() {
 
   return (
     <Tabs
+      initialRouteName="vocab/index"
       screenOptions={{
         tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
         headerShown: false,
@@ -26,20 +27,6 @@ export default function TabLayout() {
           default: {},
         }),
       }}>
-      <Tabs.Screen
-        name="index"
-        options={{
-          title: 'Home',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="house.fill" color={color} />,
-        }}
-      />
-      <Tabs.Screen
-        name="explore"
-        options={{
-          title: 'Explore',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
-        }}
-      />
       <Tabs.Screen
         name="vocab/index"
         options={{

--- a/app/(tabs)/vocab/index.tsx
+++ b/app/(tabs)/vocab/index.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'expo-router';
 import { View, FlatList, Button } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { ThemedText } from '@/components/ThemedText';
 import { useVocabulary } from '@/contexts/VocabularyContext';
 
@@ -7,7 +8,7 @@ export default function VocabularyScreen() {
   const { words } = useVocabulary();
 
   return (
-    <View style={{ flex: 1, padding: 16 }}>
+    <SafeAreaView style={{ flex: 1, padding: 16 }}>
       <View style={{ flexDirection: 'row', gap: 12, marginBottom: 12 }}>
         <Link href="/vocab/add" asChild>
           <Button title="Add Word" />
@@ -26,6 +27,6 @@ export default function VocabularyScreen() {
         )}
         ListEmptyComponent={<ThemedText>No words yet.</ThemedText>}
       />
-    </View>
+    </SafeAreaView>
   );
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,6 +2,7 @@ import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native
 import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 import 'react-native-reanimated';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
@@ -20,13 +21,15 @@ export default function RootLayout() {
 
   return (
     <VocabularyProvider>
-      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-        <Stack>
-          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-          <Stack.Screen name="+not-found" />
-        </Stack>
-        <StatusBar style="auto" />
-      </ThemeProvider>
+      <SafeAreaProvider>
+        <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+          <Stack>
+            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+            <Stack.Screen name="+not-found" />
+          </Stack>
+          <StatusBar style="auto" />
+        </ThemeProvider>
+      </SafeAreaProvider>
     </VocabularyProvider>
   );
 }

--- a/app/vocab/add.tsx
+++ b/app/vocab/add.tsx
@@ -1,6 +1,7 @@
 import { Stack, router } from 'expo-router';
 import { useState } from 'react';
-import { View, TextInput, Button } from 'react-native';
+import { TextInput, Button } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { useVocabulary } from '@/contexts/VocabularyContext';
 import { ThemedText } from '@/components/ThemedText';
@@ -17,7 +18,7 @@ export default function AddWordScreen() {
   };
 
   return (
-    <View style={{ flex: 1, padding: 16, gap: 12 }}>
+    <SafeAreaView style={{ flex: 1, padding: 16, gap: 12 }}>
       <Stack.Screen options={{ title: 'Add Word' }} />
       <ThemedText>Word</ThemedText>
       <TextInput
@@ -32,6 +33,6 @@ export default function AddWordScreen() {
         style={{ borderWidth: 1, padding: 8, borderRadius: 4 }}
       />
       <Button title="Save" onPress={handleAdd} />
-    </View>
+    </SafeAreaView>
   );
 }

--- a/app/vocab/quiz/index.tsx
+++ b/app/vocab/quiz/index.tsx
@@ -1,11 +1,11 @@
 import { Stack } from 'expo-router';
-import { View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Link } from 'expo-router';
 import { Button } from 'react-native';
 
 export default function QuizMenuScreen() {
   return (
-    <View style={{ flex: 1, padding: 16, gap: 12 }}>
+    <SafeAreaView style={{ flex: 1, padding: 16, gap: 12 }}>
       <Stack.Screen options={{ title: 'Quiz' }} />
       <Link href="/vocab/quiz/meaning" asChild>
         <Button title="Word -> Meaning" />
@@ -16,6 +16,6 @@ export default function QuizMenuScreen() {
       <Link href="/vocab/quiz/scramble" asChild>
         <Button title="Unscramble" />
       </Link>
-    </View>
+    </SafeAreaView>
   );
 }

--- a/app/vocab/quiz/meaning.tsx
+++ b/app/vocab/quiz/meaning.tsx
@@ -1,6 +1,7 @@
 import { Stack } from 'expo-router';
 import { useState } from 'react';
-import { View, Button } from 'react-native';
+import { Button } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { ThemedText } from '@/components/ThemedText';
 import { useVocabulary } from '@/contexts/VocabularyContext';
 
@@ -11,10 +12,10 @@ export default function QuizMeaningScreen() {
 
   if (words.length === 0) {
     return (
-      <View style={{ flex: 1, padding: 16 }}>
+      <SafeAreaView style={{ flex: 1, padding: 16 }}>
         <Stack.Screen options={{ title: 'Word -> Meaning' }} />
         <ThemedText>No words to practice.</ThemedText>
-      </View>
+      </SafeAreaView>
     );
   }
 
@@ -31,14 +32,14 @@ export default function QuizMeaningScreen() {
   };
 
   return (
-    <View style={{ flex: 1, padding: 16, gap: 12 }}>
+    <SafeAreaView style={{ flex: 1, padding: 16, gap: 12 }}>
       <Stack.Screen options={{ title: 'Word -> Meaning' }} />
       <ThemedText type="title">{word.word}</ThemedText>
       {options.map((m) => (
         <Button key={m} title={m} onPress={() => handleAnswer(m)} />
       ))}
       {show && <Button title="Next" onPress={next} />}
-    </View>
+    </SafeAreaView>
   );
 }
 

--- a/app/vocab/quiz/scramble.tsx
+++ b/app/vocab/quiz/scramble.tsx
@@ -1,6 +1,7 @@
 import { Stack } from 'expo-router';
 import { useState, useEffect } from 'react';
 import { View, Button } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { ThemedText } from '@/components/ThemedText';
 import { useVocabulary } from '@/contexts/VocabularyContext';
 
@@ -12,10 +13,10 @@ export default function QuizScrambleScreen() {
 
   if (words.length === 0) {
     return (
-      <View style={{ flex: 1, padding: 16 }}>
+      <SafeAreaView style={{ flex: 1, padding: 16 }}>
         <Stack.Screen options={{ title: 'Unscramble' }} />
         <ThemedText>No words to practice.</ThemedText>
-      </View>
+      </SafeAreaView>
     );
   }
 
@@ -40,7 +41,7 @@ export default function QuizScrambleScreen() {
   const solved = letters.length === 0 && answer.toLowerCase() === word.word.toLowerCase();
 
   return (
-    <View style={{ flex: 1, padding: 16, gap: 12 }}>
+    <SafeAreaView style={{ flex: 1, padding: 16, gap: 12 }}>
       <Stack.Screen options={{ title: 'Unscramble' }} />
       <ThemedText>{word.meaning}</ThemedText>
       <ThemedText type="title">{answer}</ThemedText>
@@ -50,7 +51,7 @@ export default function QuizScrambleScreen() {
         ))}
       </View>
       {solved && <Button title="Next" onPress={next} />}
-    </View>
+    </SafeAreaView>
   );
 }
 

--- a/app/vocab/quiz/word.tsx
+++ b/app/vocab/quiz/word.tsx
@@ -1,6 +1,7 @@
 import { Stack } from 'expo-router';
 import { useState } from 'react';
-import { View, Button } from 'react-native';
+import { Button } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { ThemedText } from '@/components/ThemedText';
 import { useVocabulary } from '@/contexts/VocabularyContext';
 
@@ -11,10 +12,10 @@ export default function QuizWordScreen() {
 
   if (words.length === 0) {
     return (
-      <View style={{ flex: 1, padding: 16 }}>
+      <SafeAreaView style={{ flex: 1, padding: 16 }}>
         <Stack.Screen options={{ title: 'Meaning -> Word' }} />
         <ThemedText>No words to practice.</ThemedText>
-      </View>
+      </SafeAreaView>
     );
   }
 
@@ -31,14 +32,14 @@ export default function QuizWordScreen() {
   };
 
   return (
-    <View style={{ flex: 1, padding: 16, gap: 12 }}>
+    <SafeAreaView style={{ flex: 1, padding: 16, gap: 12 }}>
       <Stack.Screen options={{ title: 'Meaning -> Word' }} />
       <ThemedText type="title">{word.meaning}</ThemedText>
       {options.map((m) => (
         <Button key={m} title={m} onPress={() => handleAnswer(m)} />
       ))}
       {show && <Button title="Next" onPress={next} />}
-    </View>
+    </SafeAreaView>
   );
 }
 


### PR DESCRIPTION
## Summary
- use `SafeAreaProvider` at the root
- remove Home and Explore tabs and make Vocabulary the default
- wrap screens with `SafeAreaView` so content isn't obscured

## Testing
- `npm run lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840038cb53083268d4bd4e1d6774180